### PR TITLE
Fix Implicitly marking parameter $dc as nullable

### DIFF
--- a/src/EventListener/DataContainer/ToolboxEditorCssCallback.php
+++ b/src/EventListener/DataContainer/ToolboxEditorCssCallback.php
@@ -24,7 +24,7 @@ class ToolboxEditorCssCallback
         $this->requestStack = $requestStack;
     }
 
-    public function __invoke(DataContainer $dc = null): void
+    public function __invoke(?DataContainer $dc = null): void
     {
         if (null === $dc || !$dc->id || 'edit' !== $this->requestStack->getCurrentRequest()->query->get('act')) {
             return;


### PR DESCRIPTION
This PR fix the "Implicitly marking parameter $dc as nullable" deprecation warning in php 8.4+