### PR TITLE
fix: apply toolbox classes on include alias elements

### DIFF
--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -41,6 +41,21 @@ class ParseTemplateListener
         $template->class .= ' '.$this->uniqueClasses($template->toolbox_classes);
     }
 
+    #[AsHook('getContentElement')]
+    public function onGetContentElement(mixed $element, string $buffer): string
+    {
+        if (!\is_object($element) || 'alias' !== ($element->type ?? null) || !($element->toolbox_classes ?? null)) {
+            return $buffer;
+        }
+
+        return preg_replace(
+            '/class="(.+?)"/',
+            \sprintf('class="$1 %s"', $this->uniqueClasses((string) $element->toolbox_classes)),
+            $buffer,
+            1,
+        ) ?? $buffer;
+    }
+
     #[AsHook('parseWidget')]
     public function onParseWidget(string $buffer, Widget $widget): string
     {


### PR DESCRIPTION
## Summary
- add a `getContentElement` hook for alias elements
- append the alias element's own `toolbox_classes` to rendered output
- keep existing parseTemplate/parseWidget behavior unchanged

## Why
Fixes #23: classes selected on include/alias elements were ignored; only classes from the source element appeared.

## Validation
- Reproduced on c57: source class `tt-source-only`, alias class `tt-include-class`
- Before: both outputs had only `tt-source-only`
- After: alias output has `tt-source-only tt-include-class`
