### PR TITLE
fix: handle empty widget class attributes for toolbox classes

### DIFF
--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -48,12 +48,22 @@ class ParseTemplateListener
             return $buffer;
         }
 
-        return preg_replace(
-            '/class="(.+?)"/',
-            \sprintf('class="$1 %s"', $this->uniqueClasses($widget->toolbox_classes)),
+        $classes = $this->uniqueClasses($widget->toolbox_classes);
+
+        // First try to append to an existing class attribute (including class="").
+        $updated = preg_replace(
+            '/class="([^"]*)"/',
+            \sprintf('class="$1 %s"', $classes),
             $buffer,
             1,
         );
+
+        if (null !== $updated && $updated !== $buffer) {
+            return str_replace('class=" "', 'class="'.$classes.'"', $updated);
+        }
+
+        // Fallback: inject class attribute into first HTML tag.
+        return preg_replace('/^<([a-zA-Z0-9:-]+)/', '<$1 class="'.$classes.'"', $buffer, 1) ?? $buffer;
     }
 
     private function uniqueClasses(string $classes): string


### PR DESCRIPTION
## Summary
- improve `parseWidget` class injection logic
- support empty class attributes (`class=""`) without producing broken whitespace-only class values
- add fallback injection when rendered widget markup has no class attribute at all

## Why
Issue #22 reports that toolbox classes are not applied when the default Contao CSS class field is empty. The previous regex matched only non-empty class values and skipped edge markup.

## Result
Toolbox classes are now appended reliably for widgets, including empty/missing class-attribute cases.

Fixes #22
