### PR TITLE
chore: backport PR #30 and #31 fixes to 4.x

### DIFF
--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -41,6 +41,21 @@ class ParseTemplateListener
         $template->class .= ' '.$this->uniqueClasses($template->toolbox_classes);
     }
 
+    #[AsHook('getContentElement')]
+    public function onGetContentElement(mixed $element, string $buffer): string
+    {
+        if (!\is_object($element) || 'alias' !== ($element->type ?? null) || !($element->toolbox_classes ?? null)) {
+            return $buffer;
+        }
+
+        return preg_replace(
+            '/class="(.+?)"/',
+            \sprintf('class="$1 %s"', $this->uniqueClasses((string) $element->toolbox_classes)),
+            $buffer,
+            1,
+        ) ?? $buffer;
+    }
+
     #[AsHook('parseWidget')]
     public function onParseWidget(string $buffer, Widget $widget): string
     {

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -71,6 +71,10 @@ class ParseTemplateListener
 
         $classes = $this->uniqueClasses($widget->toolbox_classes);
 
+        if ($classes === '') {
+            return $buffer;
+        }
+
         // First try to append to an existing class attribute (including class="").
         $updated = preg_replace(
             '/class="([^"]*)"/',

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -76,15 +76,23 @@ class ParseTemplateListener
         }
 
         // First try to append to an existing class attribute (including class="").
-        $updated = preg_replace(
+        $updated = preg_replace_callback(
             '/class="([^"]*)"/',
-            \sprintf('class="$1 %s"', $classes),
+            static function (array $matches) use ($classes): string {
+                $existing = trim($matches[1]);
+
+                if ('' === $existing) {
+                    return 'class="'.$classes.'"';
+                }
+
+                return 'class="'.$existing.' '.$classes.'"';
+            },
             $buffer,
             1,
         );
 
         if (null !== $updated && $updated !== $buffer) {
-            return str_replace('class=" "', 'class="'.$classes.'"', $updated);
+            return $updated;
         }
 
         // Fallback: inject class attribute into first HTML tag.

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -101,6 +101,26 @@ class ParseTemplateListener
 
     private function uniqueClasses(string $classes): string
     {
-        return implode(' ', array_unique(StringUtil::trimsplit(' ', $classes)));
+        // Split into tokens, trim, and remove duplicates.
+        $tokens = array_unique(StringUtil::trimsplit(' ', $classes));
+
+        // Remove empty tokens and strip unsafe characters from each class name.
+        $sanitizedTokens = [];
+        foreach ($tokens as $token) {
+            $token = trim((string) $token);
+            if ('' === $token) {
+                continue;
+            }
+
+            // Allow only a safe subset of characters in class names.
+            // This prevents breaking out of the class attribute and avoids injection.
+            $clean = preg_replace('/[^a-zA-Z0-9_-]+/', '', $token);
+
+            if ('' !== $clean) {
+                $sanitizedTokens[] = $clean;
+            }
+        }
+
+        return implode(' ', $sanitizedTokens);
     }
 }

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -44,13 +44,19 @@ class ParseTemplateListener
     #[AsHook('getContentElement')]
     public function onGetContentElement(mixed $element, string $buffer): string
     {
-        if (!\is_object($element) || 'alias' !== ($element->type ?? null) || !($element->toolbox_classes ?? null)) {
+        if (!\is_object($element) || !($element->toolbox_classes ?? null)) {
             return $buffer;
         }
 
+        if (!\in_array($element->type ?? null, ['alias', 'module'], true)) {
+            return $buffer;
+        }
+
+        $classes = $this->uniqueClasses((string) $element->toolbox_classes);
+
         return preg_replace(
             '/class="(.+?)"/',
-            \sprintf('class="$1 %s"', $this->uniqueClasses((string) $element->toolbox_classes)),
+            \sprintf('class="$1 %s"', $classes),
             $buffer,
             1,
         ) ?? $buffer;

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -69,12 +69,22 @@ class ParseTemplateListener
             return $buffer;
         }
 
-        return preg_replace(
-            '/class="(.+?)"/',
-            \sprintf('class="$1 %s"', $this->uniqueClasses($widget->toolbox_classes)),
+        $classes = $this->uniqueClasses($widget->toolbox_classes);
+
+        // First try to append to an existing class attribute (including class="").
+        $updated = preg_replace(
+            '/class="([^"]*)"/',
+            \sprintf('class="$1 %s"', $classes),
             $buffer,
             1,
         );
+
+        if (null !== $updated && $updated !== $buffer) {
+            return str_replace('class=" "', 'class="'.$classes.'"', $updated);
+        }
+
+        // Fallback: inject class attribute into first HTML tag.
+        return preg_replace('/^<([a-zA-Z0-9:-]+)/', '<$1 class="'.$classes.'"', $buffer, 1) ?? $buffer;
     }
 
     private function uniqueClasses(string $classes): string


### PR DESCRIPTION
## Summary
Backports the fixes from PR #30 and PR #31 (merged into `3.0`) to `4.x`.

Included fixes:
- apply `toolbox_classes` to alias/module include rendering (`getContentElement`)
- handle empty widget `class=""` safely
- use callback-based class replacement for widgets
- sanitize/normalize class tokens in `uniqueClasses()`

## Source PRs
- #30
- #31

## Notes
This is a straight cherry-pick backport of the original commits so behavior stays aligned between `3.0` and `4.x`.